### PR TITLE
Update company name in MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Nethermind
+Copyright (c) 2025 DEMERZEL SOLUTIONS LTD
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This PR updates the company name in the MIT license from 'Nethermind' to 'DEMERZEL SOLUTIONS LTD'.